### PR TITLE
fix: add description line to README (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+Test repo for goclaw vault e2e
 # Test Repo


### PR DESCRIPTION
Fixes #6

Added a single-line description at the top of README.md: 'Test repo for goclaw vault e2e'.